### PR TITLE
US 3 Merchant Bulk Discount Delete

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,7 +1,6 @@
 class BulkDiscountsController < ApplicationController
   def index
     @merchant = Merchant.find(params[:merchant_id])
-    @bulk_discounts = @merchant.bulk_discounts
   end
 
   def new
@@ -21,6 +20,13 @@ class BulkDiscountsController < ApplicationController
       flash[:alert] = "Bulk Discount was successfully created!"   
       redirect_to merchant_bulk_discounts_path(@merchant)
     end
+  end
+
+  def destroy
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = BulkDiscount.find(params[:id])
+    @bulk_discount.destroy
+    redirect_to merchant_bulk_discounts_path(@merchant)
   end
 
   private

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -5,7 +5,6 @@
         <li>Percentage Discount: <%= (number_with_precision(bulk_discount.percentage_discount * 100, precision: 2).gsub(/\.?0*$/, '') + '%') %></li>
         <li>Quantity Threshold: <%= bulk_discount.quantity_threshold %></li>
         <li><%= link_to "Discount Details", merchant_bulk_discount_path(@merchant, bulk_discount) %></li><br>
-      </ul>
     <% end %>
 </section><br>
 <p><%= link_to "Create New Bulk Discount", new_merchant_bulk_discount_path(@merchant) %></p>

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,10 +1,16 @@
 <h1><%= @merchant.name %> Bulk Discounts</h1><br>
 <section id="bulk_discount-index-<%= @merchant.id %>">
-    <% @bulk_discounts.each do |bulk_discount|%>
-      <ul>
-        <li>Percentage Discount: <%= (number_with_precision(bulk_discount.percentage_discount * 100, precision: 2).gsub(/\.?0*$/, '') + '%') %></li>
-        <li>Quantity Threshold: <%= bulk_discount.quantity_threshold %></li>
-        <li><%= link_to "Discount Details", merchant_bulk_discount_path(@merchant, bulk_discount) %></li><br>
-    <% end %>
+  <% @merchant.bulk_discounts.each do |bulk_discount|%>
+    <ul>
+      <li>Percentage Discount: <%= (number_with_precision(bulk_discount.percentage_discount * 100,precision: 2).gsub(/\.?0*$/, '') + '%') %></li>
+      <li>Quantity Threshold: <%= bulk_discount.quantity_threshold %></li>
+      <li><%= link_to "Discount Details",merchant_bulk_discount_path(@merchant, bulk_discount) %></li>
+      <%= form_with(model: bulk_discount, url: "/merchants/#{@merchant.id}/bulk_discounts/#{bulk_discount.id}", method: :delete, data: { turbo: false }) do |form| %>
+        <%= form.hidden_field :authenticity_token,value: form_authenticity_token %>
+        <%= form.hidden_field :_method, value: "DELETE"%>
+        <%= form.submit "Delete This Bulk Discount" %></li>
+      <% end %>
+    </ul>
+  <% end %>
 </section><br>
 <p><%= link_to "Create New Bulk Discount", new_merchant_bulk_discount_path(@merchant) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -72,6 +72,39 @@ RSpec.describe "merchant bulk disounts index page" do
           
         expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant1))
       end
-    end   
+    end
+
+    it "then next to each bulk discount I see a button to delete it and when I click this button, I am then redirected back to the bulk discounts index page
+    and I no longer see the discount listed" do
+      visit merchant_bulk_discounts_path(@merchant1.id)
+      
+      expect(page).to have_content("25%")
+      expect(page).to have_content(@bulk_discounts_1.quantity_threshold)
+      expect(page).to have_link("Discount Details")
+      expect(page).to have_button("Delete This Bulk Discount")
+
+      expect(page).to have_content("35%")
+      expect(page).to have_content(@bulk_discounts_2.quantity_threshold)
+      expect(page).to have_link("Discount Details")
+      expect(page).to have_button("Delete This Bulk Discount")
+
+      expect(page).to have_content("55%")
+      expect(page).to have_content(@bulk_discounts_1.quantity_threshold)
+      expect(page).to have_link("Discount Details")
+      expect(page).to have_button("Delete This Bulk Discount")
+
+      expect(page).to have_no_content("15%")
+      expect(page).to have_no_content("45%")
+      expect(page).to have_no_content("65%")
+      expect(page).to have_no_content(@bulk_discounts_4.quantity_threshold)
+      expect(page).to have_no_content(@bulk_discounts_5.quantity_threshold)
+      expect(page).to have_no_content(@bulk_discounts_6.quantity_threshold)
+
+      click_button "Delete This Bulk Discount"
+
+      expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1.id))
+      expect(page).to have_no_content("25%")
+      expect(page).to have_no_content(@bulk_discounts_1.quantity_threshold)
+    end
   end
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -4,13 +4,15 @@ RSpec.describe "merchant bulk disounts index page" do
   before(:each) do
     @merchant1 = Merchant.create!(name: "Hair Care")
     @merchant2 = Merchant.create!(name: "Chair Fair")
-
+    @merchant3 = Merchant.create!(name: "Voltaire Hair")
+    
     @bulk_discounts_1 = BulkDiscount.create!(percentage_discount: 0.25, quantity_threshold: 7, merchant_id: @merchant1.id)
     @bulk_discounts_2 = BulkDiscount.create!(percentage_discount: 0.35, quantity_threshold: 10, merchant_id: @merchant1.id)
     @bulk_discounts_3 = BulkDiscount.create!(percentage_discount: 0.55, quantity_threshold: 16, merchant_id: @merchant1.id)
     @bulk_discounts_4 = BulkDiscount.create!(percentage_discount: 0.15, quantity_threshold: 8, merchant_id: @merchant2.id)
     @bulk_discounts_5 = BulkDiscount.create!(percentage_discount: 0.45, quantity_threshold: 9, merchant_id: @merchant2.id)
     @bulk_discounts_6 = BulkDiscount.create!(percentage_discount: 0.65, quantity_threshold: 12, merchant_id: @merchant2.id)
+    @bulk_discounts_7 = BulkDiscount.create!(percentage_discount: 0.75, quantity_threshold: 15, merchant_id: @merchant3.id)
   end
 
   describe "As a merchant" do
@@ -76,35 +78,18 @@ RSpec.describe "merchant bulk disounts index page" do
 
     it "then next to each bulk discount I see a button to delete it and when I click this button, I am then redirected back to the bulk discounts index page
     and I no longer see the discount listed" do
-      visit merchant_bulk_discounts_path(@merchant1.id)
+      visit merchant_bulk_discounts_path(@merchant3.id)
       
-      expect(page).to have_content("25%")
-      expect(page).to have_content(@bulk_discounts_1.quantity_threshold)
+      expect(page).to have_content("75%")
+      expect(page).to have_content(@bulk_discounts_7.quantity_threshold)
       expect(page).to have_link("Discount Details")
       expect(page).to have_button("Delete This Bulk Discount")
-
-      expect(page).to have_content("35%")
-      expect(page).to have_content(@bulk_discounts_2.quantity_threshold)
-      expect(page).to have_link("Discount Details")
-      expect(page).to have_button("Delete This Bulk Discount")
-
-      expect(page).to have_content("55%")
-      expect(page).to have_content(@bulk_discounts_1.quantity_threshold)
-      expect(page).to have_link("Discount Details")
-      expect(page).to have_button("Delete This Bulk Discount")
-
-      expect(page).to have_no_content("15%")
-      expect(page).to have_no_content("45%")
-      expect(page).to have_no_content("65%")
-      expect(page).to have_no_content(@bulk_discounts_4.quantity_threshold)
-      expect(page).to have_no_content(@bulk_discounts_5.quantity_threshold)
-      expect(page).to have_no_content(@bulk_discounts_6.quantity_threshold)
 
       click_button "Delete This Bulk Discount"
 
-      expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1.id))
-      expect(page).to have_no_content("25%")
-      expect(page).to have_no_content(@bulk_discounts_1.quantity_threshold)
+      expect(current_path).to eq(merchant_bulk_discounts_path(@merchant3.id))
+      expect(page).to have_no_content("75%")
+      expect(page).to have_no_content(@bulk_discounts_7.quantity_threshold)
     end
   end
 end


### PR DESCRIPTION
## Description
This PR allows a `Merchant` to delete a `Bulk Discount` from the `Bulk Discount` Index page. There is a button `Delete This Bulk Discount` below the `Bulk Discount` that the `Merchant` can click on and then they will be redirected to the `Bulk Discount` Index page where they will see that `Bulk Discount` removed.  

I have also deployed this app via Heroku! 

## Type of Change

- [ ] **fix**
- [x] **feat**
- [x] **test**
- [x] **refactor**
- [ ] **docs**

## Checklist

- [x] **Code has been self reviewed**
- [x] **Code runs without any errors**
- [x] **Thorough testing has been implemented if adding feature**
- [x] **All tests pass**
